### PR TITLE
Add integrity hash into Grunt config

### DIFF
--- a/tasks/sri.js
+++ b/tasks/sri.js
@@ -144,7 +144,7 @@ task = function () {
                 // Attach a property to the WIP manifest object
                 manifest[file.id] = sriData;
 
-                grunt.config(['sri','data', file.id.substring(1)], sriData.integrity);
+                grunt.config(["sri", "data", file.id.substring(1)], sriData.integrity);
                 callback(err, manifest);
             });
         },

--- a/tasks/sri.js
+++ b/tasks/sri.js
@@ -143,6 +143,8 @@ task = function () {
                 }
                 // Attach a property to the WIP manifest object
                 manifest[file.id] = sriData;
+
+                grunt.config(['sri','data', file.id.substring(1)], sriData.integrity);
                 callback(err, manifest);
             });
         },


### PR DESCRIPTION
Relates to #3.

If the integrity hash was injected in the config, then we could use it in other Grunt tasks (e.g. processhtml) to write the hash into the html without having to load the file.